### PR TITLE
R minimal docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM r-base:3.6.1
+FROM r-base:3.6.2
 
 ENV R_FORGE_PKGS Rserve
 ENV R_CRAN_PKGS Rcpp R6 uuid checkmate mime jsonlite

--- a/docker/Dockerfile-r-minimal
+++ b/docker/Dockerfile-r-minimal
@@ -1,0 +1,21 @@
+FROM rexyai/r-minimal
+
+ENV R_CRAN_PKGS Rcpp R6 uuid checkmate mime jsonlite
+
+COPY . /tmp/RestRserve
+
+RUN apk update && \
+    apk add --no-cache --virtual .build-deps gcc g++ musl-dev openssl-dev && \
+    installr -d $R_CRAN_PKGS && \
+    Rscript -e "install.packages('Rserve', repos = 'http://www.rforge.net/')" && \
+    R CMD build --no-manual --no-build-vignettes /tmp/RestRserve && \
+    R CMD INSTALL /RestRserve*.tar.gz && \
+    rm -rf /tmp/RestRserve* && \
+    rm /RestRserve*.tar.gz && \
+    apk del .build-deps
+
+WORKDIR /
+
+EXPOSE 8080
+
+CMD ["Rscript", "-e", "source(system.file('examples', 'hello', 'app.R', package = 'RestRserve')); backend$start(app, http_port = 8080)"]


### PR DESCRIPTION
This adds docker image based on Alpine linux. It is really small - 62 mb uncompressed (compared to debian-based 750mb from rocker project!) and it seems works just fine in most of the cases. However:
- keep in mind that MUSL is less common than glibc, so sometimes issues arise. For example - https://github.com/dmlc/xgboost/issues/5131.
- we don't add alternative malloc in this PR (this is for further investigation - see for example https://github.com/microsoft/mimalloc). So [this issue](https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17505) is valid to some extend. Not a big deal though - Rserve forks and kills processes, so memory fragmentation doesn't hurt too much.

Fixes #115 