### PR TITLE
0.2.0.1 RC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ after_success:
   - Rscript -e 'covr::codecov()'
   - R CMD INSTALL $PKG_TARBALL
   - Rscript -e 'lintr::lint_package()'
-  - Rscript -e 'pkgdown::build_site()'
+  - Rscript -e 'pkgdown::build_site(examples = FALSE)'
 
 deploy:
   provider: pages

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM r-base:3.6.2
+FROM rocker/r-ver:3.6.2
 
 ENV R_FORGE_PKGS Rserve
 ENV R_CRAN_PKGS Rcpp R6 uuid checkmate mime jsonlite


### PR DESCRIPTION
- make base docker image rocker/r-ver:3.6.2
- don't run examples during website build