### PR TITLE
Fix header name validation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,13 +2,13 @@ Package: RestRserve
 Type: Package
 Title: A Framework for Building HTTP API
 Description:
-  Allows to easily create high-performance full featured HTTP APIs from R 
-  functions. Provides high-level classes such as 'Request', 'Response', 
-  'Application', 'Middleware' in order to streamline server side 
-  application development. Out of the box allows to serve requests using 
+  Allows to easily create high-performance full featured HTTP APIs from R
+  functions. Provides high-level classes such as 'Request', 'Response',
+  'Application', 'Middleware' in order to streamline server side
+  application development. Out of the box allows to serve requests using
   'Rserve' package, but flexible enough to integrate with other HTTP servers
   such as 'httpuv'.
-Version: 0.2.0.2
+Version: 0.2.0.3
 Authors@R: c(
   person(given = "Dmitriy",
          family = "Selivanov",

--- a/inst/tinytest/test-parse-headers.R
+++ b/inst/tinytest/test-parse-headers.R
@@ -24,11 +24,12 @@ Connection: keep-alive\r\n
 Cookie: prov=f1e12498-1231-c8f0-8f53-97a8a6b17754; notice-ctt=4%3B1560153827826; mfnes=6e32CJ0CEAMaCwishdGGwpPLNxAFIJsCKAEyCDYyZGY0OTJh; acct=t=cmBi7gQEMWgxdi6kOiPwqAVNqmbEPdVj&s=E9Ly%2bCeEeAGmK9wDx2Zaseg6tiyi2hd8; sgt=id=3f4b96f5-b5ef-4ab1-96af-5ebce2950bcc\r\n
 Upgrade-Insecure-Requests: 1\r\n
 Cache-Control: max-age=0\r\n
+Custom_name: custom value
 TE: Trailers\r\n\r\n"
 
 parsed = parse_headers(h)
 expect_true(inherits(parsed, "list"))
-expect_equal(length(parsed), 12L)
+expect_equal(length(parsed), 13L)
 expect_equal(parsed[["connection"]], "keep-alive")
 expect_equal(parsed[["accept"]], c("text/html", "application/xhtml+xml", "application/xml"))
 expect_equal(parsed[["user-agent"]], "Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0")
@@ -36,4 +37,5 @@ expect_equal(parsed[["accept-encoding"]], c("gzip", "deflate", "br"))
 expect_equal(parsed[["accept-language"]], c("ru-RU", "ru"))
 expect_equal(length(parsed[["cookie"]]), 5L)
 expect_equal(parsed[["cookie"]][[1L]], "prov=f1e12498-1231-c8f0-8f53-97a8a6b17754")
+expect_equal(parsed[["custom_name"]], "custom value")
 # nolint end

--- a/inst/tinytest/test-parse-headers.R
+++ b/inst/tinytest/test-parse-headers.R
@@ -10,6 +10,7 @@ expect_true(inherits(parse_headers(NA_character_), "list"))
 expect_equal(length(parse_headers(NA_character_)), 0L)
 expect_true(inherits(parse_headers(""), "list"))
 expect_equal(length(parse_headers("")), 0L)
+expect_error(parse_headers("param\u100: value"), "header contains invalid character.")
 
 # Test fields
 # nolint start

--- a/src/parse_headers.cpp
+++ b/src/parse_headers.cpp
@@ -8,8 +8,8 @@
 using Headers = std::unordered_map<std::string, std::vector<std::string>>;
 
 bool validate_header_name(const std::string& x) {
-  auto check = [&](char c) { return std::isalpha(c) || c == '-'; };
-  return std::all_of(x.begin(), x.end(), check);
+  const char* valid = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890!#$%&'*+-.^_`|~";
+  return x.find_first_not_of(valid) == std::string::npos;
 }
 
 // [[Rcpp::export(rng=false)]]


### PR DESCRIPTION
Fix #132. 
- rewrite `validate_header_name`
- add tests
- update patch version to 0.2.0.3