### PR TITLE
Add further ETag headers

### DIFF
--- a/R/ETagMiddleware.R
+++ b/R/ETagMiddleware.R
@@ -232,6 +232,25 @@ ETagMiddleware = R6::R6Class(
         }
 
 
+        # Check If-Unmodified-Since Header
+        ius = request$get_header("if-unmodified-since", NULL)
+
+        if (!is.null(ius) && is.null(inm)) {
+          ius_date = as.POSIXlt(paste(ius, sep = ", "), tryFormats = c(
+            time_fmt, "%FT%TZ", "%Y-%m-%d %H:%M:%OS", "%Y/%m/%d %H:%M:%OS",
+            "%Y-%m-%d %H:%M", "%Y/%m/%d %H:%M", "%Y-%m-%d", "%Y/%m/%d"
+          ), tz = "GMT")
+
+          # if ius_date is after modified date, it triggers
+          if (last_modified > ius_date) {
+            response$set_body(NULL)
+            response$set_status_code(412)
+            return()
+          }
+        }
+
+
+
         # No Caching... Add Last Modified and ETag header
         response$set_header("Last-Modified", format(last_modified, time_fmt))
         response$set_header("ETag", actual_hash)

--- a/R/ETagMiddleware.R
+++ b/R/ETagMiddleware.R
@@ -211,7 +211,7 @@ ETagMiddleware = R6::R6Class(
         # INM takes precedence over IMS,
         # that is if IMS is only checked if INM is NOT GIVEN!
         if (!is.null(ims) && is.null(inm)) {
-          ims_date = as.POSIXlt(ims, tryFormats = c(
+          ims_date = as.POSIXlt(paste(ims, sep = ", "), tryFormats = c(
             time_fmt, "%FT%TZ", "%Y-%m-%d %H:%M:%OS", "%Y/%m/%d %H:%M:%OS",
             "%Y-%m-%d %H:%M", "%Y/%m/%d %H:%M", "%Y-%m-%d", "%Y/%m/%d"
           ), tz = "GMT")

--- a/R/ETagMiddleware.R
+++ b/R/ETagMiddleware.R
@@ -195,12 +195,11 @@ ETagMiddleware = R6::R6Class(
         inm = request$get_header("if-none-match", NULL)
         actual_hash = self$hash_function(response$body)
 
-        if (!is.null(inm)) {
-          if (inm == actual_hash) {
-            response$set_body(NULL)
-            response$set_status_code(304)
-            return()
-          }
+        if (!is.null(inm) && actual_hash %in% inm) {
+          response$set_body(NULL)
+          response$set_status_code(304)
+          return()
+        }
         }
 
 

--- a/R/ETagMiddleware.R
+++ b/R/ETagMiddleware.R
@@ -200,6 +200,14 @@ ETagMiddleware = R6::R6Class(
           response$set_status_code(304)
           return()
         }
+
+
+        # Check If-Match Header
+        im = request$get_header("if-match", NULL)
+        if (!is.null(im) && !actual_hash %in% im && !"*" %in% im) {
+          response$set_body(NULL)
+          response$set_status_code(412)
+          return()
         }
 
 

--- a/inst/tinytest/test-etag.R
+++ b/inst/tinytest/test-etag.R
@@ -138,6 +138,7 @@ rs = app$process_request(req)
 expect_cached(rs)
 
 
+
 # Multiple If-None-Match
 req = Request$new(
   path = "/static/example.txt",
@@ -146,6 +147,7 @@ req = Request$new(
 )
 rs = app$process_request(req)
 expect_cached(rs)
+
 
 
 # Only If None Match but WRONG resulting in the file to be returned
@@ -158,6 +160,7 @@ rs = app$process_request(req)
 expect_no_cached_file(rs, file_path, last_modified)
 
 
+
 # Check If-Match Header
 req = Request$new(
   path = "/static/example.txt",
@@ -166,6 +169,7 @@ req = Request$new(
 )
 rs = app$process_request(req)
 expect_no_cached_file(rs, file_path, last_modified)
+
 
 
 # Check If-Match Header with other hash
@@ -178,6 +182,7 @@ rs = app$process_request(req)
 expect_equal(rs$status_code, 412)
 
 
+
 # Check If-Match Header with multiple values
 req = Request$new(
   path = "/static/example.txt",
@@ -186,6 +191,7 @@ req = Request$new(
 )
 rs = app$process_request(req)
 expect_no_cached_file(rs, file_path, last_modified)
+
 
 
 # Check If-Match Header matching any
@@ -198,6 +204,7 @@ rs = app$process_request(req)
 expect_no_cached_file(rs, file_path, last_modified)
 
 
+
 # Check If-Match Header wrong hash
 req = Request$new(
   path = "/static/example.txt",
@@ -206,6 +213,29 @@ req = Request$new(
 )
 rs = app$process_request(req)
 expect_equal(rs$status_code, 412)
+
+
+
+# Check If-Unmodified-Since Header
+req = Request$new(
+  path = "/static/example.txt",
+  method = "GET",
+  headers = list("If-Unmodified-Since" = format(last_modified - 1, time_fmt))
+)
+rs = app$process_request(req)
+expect_equal(rs$status_code, 412)
+
+
+
+# Check If-Unmodified-Since Header other case
+req = Request$new(
+  path = "/static/example.txt",
+  method = "GET",
+  headers = list("If-Unmodified-Since" = format(last_modified + 1, time_fmt))
+)
+rs = app$process_request(req)
+expect_no_cached_file(rs, file_path, last_modified)
+
 
 
 # if-none-match takes precedence over If-modified-since

--- a/inst/tinytest/test-etag.R
+++ b/inst/tinytest/test-etag.R
@@ -158,6 +158,55 @@ rs = app$process_request(req)
 expect_no_cached_file(rs, file_path, last_modified)
 
 
+# Check If-Match Header
+req = Request$new(
+  path = "/static/example.txt",
+  method = "GET",
+  headers = list("If-Match" = actual_hash)
+)
+rs = app$process_request(req)
+expect_no_cached_file(rs, file_path, last_modified)
+
+
+# Check If-Match Header with other hash
+req = Request$new(
+  path = "/static/example.txt",
+  method = "GET",
+  headers = list("If-Match" = "OTHER HASH")
+)
+rs = app$process_request(req)
+expect_equal(rs$status_code, 412)
+
+
+# Check If-Match Header with multiple values
+req = Request$new(
+  path = "/static/example.txt",
+  method = "GET",
+  headers = list("If-Match" = c("SOME HASH", actual_hash, "OTHER HASH"))
+)
+rs = app$process_request(req)
+expect_no_cached_file(rs, file_path, last_modified)
+
+
+# Check If-Match Header matching any
+req = Request$new(
+  path = "/static/example.txt",
+  method = "GET",
+  headers = list("If-Match" = "*")
+)
+rs = app$process_request(req)
+expect_no_cached_file(rs, file_path, last_modified)
+
+
+# Check If-Match Header wrong hash
+req = Request$new(
+  path = "/static/example.txt",
+  method = "GET",
+  headers = list("If-Match" = "WRONG HASH")
+)
+rs = app$process_request(req)
+expect_equal(rs$status_code, 412)
+
 
 # if-none-match takes precedence over If-modified-since
 # In this test, the if-none-match header is clearly wrong

--- a/inst/tinytest/test-etag.R
+++ b/inst/tinytest/test-etag.R
@@ -138,6 +138,15 @@ rs = app$process_request(req)
 expect_cached(rs)
 
 
+# Multiple If-None-Match
+req = Request$new(
+  path = "/static/example.txt",
+  method = "GET",
+  headers = list("If-None-Match" = c("SOME HASH", actual_hash, "OTHER HASH"))
+)
+rs = app$process_request(req)
+expect_cached(rs)
+
 
 # Only If None Match but WRONG resulting in the file to be returned
 req = Request$new(

--- a/man/ETagMiddleware.Rd
+++ b/man/ETagMiddleware.Rd
@@ -4,14 +4,17 @@
 \alias{ETagMiddleware}
 \title{Creates ETag middleware object}
 \description{
-Adds ETag to \link{Application}. TBD. \cr
+Adds ETag to an \link{Application}. \cr
 
 ETags are header information that enable the caching of content.
 If enabled, RestRserve will return an ETag (eg a hash of a file) alongside
 the last time it was modified.
 When a request is sent, additional headers such as
-\href{https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match}{\code{If-None-Match}}
-or \href{https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since}{\code{If-Modified-Since}}
+\href{https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match}{\code{If-None-Match}},
+\href{https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match}{\code{If-Match}},
+\href{https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since}{\code{If-Modified-Since}},
+and
+\href{https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-UnModified-Since}{\code{If-Unmodified-Since}},
 can be passed to the server as well.
 
 If the conditions are met (different hash in case of a \code{If-None-Match} header
@@ -23,26 +26,51 @@ code, indicating, that the data on the requesting device is up-to-date.
 Note that if both headers are provided, the \code{If-None-Match} header takes
 precedence.
 
+Furthermore, the middleware also supports the headers \code{If-Match}, which
+returns the object if the hash matches (it also supports "*" to always return
+the file), as well as \code{If-Unmodified-Since}, which returns the object if it
+has not been modified since a certain time.
+If the conditions are not met, a
+\href{https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412}{412} status
+code is returned (Precondition Failed).
+See examples below.
+
 See examples below for further clarifications.
 }
 \examples{
+#############################################################################
 # setup a static directory with ETag caching
+
 static_dir = file.path(tempdir(), "static")
 if (!dir.exists(static_dir)) dir.create(static_dir)
+
 file_path = file.path(static_dir, "example.txt")
 writeLines("Hello World", file_path)
-last_modified = file.info(file_path)[["mtime"]]
+
+# get the time the file was last modified in UTC time
+last_modified = as.POSIXlt(file.info(file_path)[["mtime"]], tz = "UTC")
 file_hash = digest::digest(file = file_path, algo = "crc32")
+
+time_fmt = "\%a, \%d \%b \%Y \%H:\%M:\%S GMT"
+
+
 
 #############################################################################
 # setup the Application with the ETag Middleware
-app = Application$new(middleware = list(ETagMiddleware$new()))
+app = Application$new()
+app$append_middleware(ETagMiddleware$new())
 app$add_static(path = "/", static_dir)
+
+
+
+#############################################################################
+# Example Requests
 
 # Request the file returns the file with ETag headers
 req = Request$new(path = "/example.txt")
 # note that it also returns the Last-Modified and ETag headers
 app$process_request(req)
+
 
 # provide matching hash of the file in the If-None-Match header to check Etag
 # => 304 Not Modified (Can be cached)
@@ -51,28 +79,50 @@ req = Request$new(path = "/example.txt",
 # note status_code 304 Not Modified
 app$process_request(req)
 
+
 # provide a wrong hash, returns the file normally
 req = Request$new(path = "/example.txt",
                   headers = list("If-None-Match" = "WRONG HASH"))
 app$process_request(req)
 
+
 # alternatively, you can provide a timestamp in the If-Modified-Since header
 # => 304 Not Modified (Can be cached)
-modified_since = format(last_modified + 1, "\%FT\%TZ")
+modified_since = format(last_modified + 1, time_fmt)
 req = Request$new(path = "/example.txt",
                   headers = list("If-Modified-Since" = modified_since))
 app$process_request(req)
+
 
 # provide both headers: If-None-Match takes precedence
 # in this case:
 #  - if none match => modified (No cache)
 #  - if modified since => NOT MODIFIED (cached)
 # => Overall: modified = no cache
-modified_since = format(last_modified + 1, "\%FT\%TZ")
+modified_since = format(last_modified + 1, time_fmt)
 req = Request$new(path = "/example.txt",
                   headers = list("If-None-Match" = "CLEARLY WRONG",
                                  "If-Modified-Since" = modified_since))
 app$process_request(req)
+
+
+# provide matching hash of the file in the If-Match header to check Etag
+# => 412 Precondition Failed
+req = Request$new(path = "/example.txt",
+                  headers = list("If-Match" = "OTHER HASH"))
+# note status_code 412 Precondition Failed
+app$process_request(req)
+
+
+# Use If-Unmodified-Since
+unmodified_since = format(last_modified - 1, time_fmt)
+req = Request$new(path = "/example.txt",
+                  headers = list("If-Unmodified-Since" = unmodified_since)
+)
+# note status_code 412 Precondition Failed
+app$process_request(req)
+
+
 
 #############################################################################
 
@@ -81,12 +131,16 @@ hash_on_filename = function(x) x
 # also use an alternate last_modified time function
 always_1900 = function(x) as.POSIXlt("1900-01-01 12:34:56", tz = "GMT")
 
+
+# setup the app again
 app = Application$new(middleware = list(
   ETagMiddleware$new(hash_function = hash_on_filename,
                      last_modified_function = always_1900)
 ))
 app$add_static(path = "/", file_path = static_dir)
 
+
+# test the requests
 req = Request$new(path = "/example.txt")
 (res = app$process_request(req))
 


### PR DESCRIPTION
This PR adds the `If-Match` and `If-Unmodified-Since` headers that were still missing from the earlier PR.
NOTE that all the functionality is handled by `process_response` not `process_request`, therefore the PUT functionality described in [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match) cannot be performed (Eg update a database only if it matches something or so) or in other words the ETag we have at the moment is catered towards values being returned and not values being send to the API.

The additional headers are documented and tested.
This PR also adds a small safeguard against split date headers.