### PR TITLE
Look for error class instead of simpleError - fixes #207

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description:
   application development. Out of the box allows to serve requests using
   'Rserve' package, but flexible enough to integrate with other HTTP servers
   such as 'httpuv'.
-Version: 1.2.1
+Version: 1.2.2
 Authors@R: c(
   person(given = "Dmitry",
          family = "Selivanov",

--- a/R/Application.R
+++ b/R/Application.R
@@ -547,7 +547,7 @@ Application = R6::R6Class(
         # HTTPError response
         x = x$response
       } else {
-        if (inherits(x, "simpleError")) {
+        if (inherits(x, "error")) {
           # means UNHANDLED exception in middleware
           self$logger$error(
             "",


### PR DESCRIPTION
See https://github.com/rexyai/RestRserve/issues/207 for reference.

I have tested this out and it fixes the issue and doesn't seem to introduce issues (based on `check()`).

I didn't add any new unit tests because I didn't want to add another explicit dependency on `rlang` without permission of the authors.